### PR TITLE
Get signature validation to work

### DIFF
--- a/src/main/kotlin/com/example/plugins/Routing.kt
+++ b/src/main/kotlin/com/example/plugins/Routing.kt
@@ -21,8 +21,8 @@ import java.util.Base64
 fun Application.configureRouting() {
 
     val RSA_PUBLIC_KEY_STR = """-----BEGIN PUBLIC KEY-----
-    removed!!
-    -----END PUBLIC KEY-----""".trimIndent()
+
+-----END PUBLIC KEY-----"""
 
     val keyFactory = KeyFactory.getInstance("RSA")
 
@@ -38,14 +38,14 @@ fun Application.configureRouting() {
     // Starting point for a Ktor app:
     routing {
         post("/validatesignature") {
-            val jsonPayloadStr = call.receive<JsonNode>().toString()
+            val jsonPayloadStr = call.receive<String>()
             val xJwsSignature = call.request.header("x-jws-signature")
 
             println("jsonPayloadStr : " + jsonPayloadStr)
             println("xJwsSignature : " + xJwsSignature)
 
             val jwsObject = JWSObject.parse(xJwsSignature, Payload(jsonPayloadStr))
-
+            println("JWEOBJECT: " + jwsObject.toString())
             val verifier = RSASSAVerifier(RSA_PUBLIC_KEY as RSAPublicKey)
 
             // when


### PR DESCRIPTION
Previously, the JSON was having the whitespaces removed. This was causing the signature to be different than the one created by Larky. 

Example Curl Request:

curl -i -X POST http://0.0.0.0:8080/validatesignature \
-H "X-jws-signature: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..gWESKOgIGZeLhcU4WVkN0L6o3p6Hy2pVBt6PaiHxuEotKoXrfN0T85IEyONl65qI_7Hj8sPXOy8IcjNNrk5yiqVoR5eogl4PzfKtTuDsQr-MTJ9gHVV21pALMJdbRIQLsyFieiLCrH9jukrC1MnyYdgsjratVRaWWtsyXHDrt2B04It-OZKaDEF2_XTseXSIM-tX2wzYH--zgx0d0bp2CNp08k39PabTwhWocUM8jSGALmh4BXy0rhY_UqpiDevTQOsXdGM7WsHuQEChrgdLRxLv1Ba_6XBJzZytdFEMYyWmkCmGYJjMba2SzBR7RBx_stlKFZBiORZXjAyLEEBiFA" \
-d '{"z": "test", "a": "123", "c": "this is a test", "d": [{"new_value": 123}, {"second_value": "sdfdsf"}]}' \
-H "Content-type: text/plain"

HTTP/1.1 200 OK
Content-Type: application/json
transfer-encoding: chunked

"valid signature found"%